### PR TITLE
Ensure that the generated RSA key has the desired length

### DIFF
--- a/rsa2.js
+++ b/rsa2.js
@@ -72,6 +72,9 @@ function RSAGenerate(B,E) {
       this.q = new BigInteger(qs,1,rng);
       if(this.q.subtract(BigInteger.ONE).gcd(ee).compareTo(BigInteger.ONE) == 0 && this.q.isProbablePrime(10)) break;
     }
+    var tmp_n = this.p.multiply(this.q);
+    if(tmp_n.bitLength() < B) continue;
+
     if(this.p.compareTo(this.q) <= 0) {
       var t = this.p;
       this.p = this.q;
@@ -81,7 +84,7 @@ function RSAGenerate(B,E) {
     var q1 = this.q.subtract(BigInteger.ONE);
     var phi = p1.multiply(q1);
     if(phi.gcd(ee).compareTo(BigInteger.ONE) == 0) {
-      this.n = this.p.multiply(this.q);
+      this.n = tmp_n;
       this.d = ee.modInverse(phi);
       this.dmp1 = this.d.mod(p1);
       this.dmq1 = this.d.mod(q1);


### PR DESCRIPTION
Currently it is possible that RSAGenerate generates RSA keys with a public key of length `B-1` instead of `B` (for example 1023 bit instead of 1024 bit). For use cases that require specific bit lengths (for example Certificate Authorities), that will not work. The patch adds a check to the bit length of the public key (n). If the length is less than B (desired bit length), p and q are chosen again.

There was another option, where the two most significant bits of both p and q would be tested (independently) and re-generated when both were not significant.

I profiled both methods and found out that the method in the commit has less overhead. I profiled all three methods with 100 keys each.

```
Original               22s
Method from patch      30s (+36%)
Significant-bit-method 36s (+63%)
```

Still, this commit increases the time to generate keys in some cases significantly. In ~33% of the key generations the run-time nearly doubled.
**But** it is important to notice the original library didn't generate correct keys in that cases. So actually, this fixes a serious bug in the original library that led to the generation of faulty keys in 33% of the cases but was faster.
