### PR TITLE
Fix RSAEncrypt padding

### DIFF
--- a/rsa.js
+++ b/rsa.js
@@ -24,6 +24,10 @@ function byte2Hex(b) {
     return b.toString(16);
 }
 
+function pad(value, length) {
+  return (value.toString().length < length) ? pad("0"+value, length):value;
+}
+
 // PKCS#1 (type 2, random) pad input string s to n bytes, and return a bigint
 function pkcs1pad2(s,n) {
   if(n < s.length + 11) { // TODO: fix for utf-8
@@ -99,7 +103,7 @@ function RSAEncrypt(text) {
   var c = this.doPublic(m);
   if(c == null) return null;
   var h = c.toString(16);
-  if((h.length & 1) == 0) return h; else return "0" + h;
+  return pad(h, 512);
 }
 
 // Return the PKCS#1 RSA encryption of "text" as a Base64-encoded string


### PR DESCRIPTION
There is a bug in the `RSAEncrypt` function pulled from
[jsbn's rsa.js](http://www-cs-students.stanford.edu/~tjw/jsbn/)
where the result of the RSAEncryption is not properly left-paded.

Per http://tools.ietf.org/html/rfc2437#section-7.2.1;
1. Convert the ciphertext representative c to a ciphertext C of
        length k octets: C = I2OSP (c, k)

where `k` is the length in octets of the modulus
